### PR TITLE
Update FindECW.cmake

### DIFF
--- a/cmake/modules/packages/FindECW.cmake
+++ b/cmake/modules/packages/FindECW.cmake
@@ -16,6 +16,10 @@
 # Copyright (C) 2017,2018 Hiroshi Miura
 ################################################################################
 
+if(NOT ECW_ROOT AND DEFINED ENV{ECW_ROOT})
+  set(ECW_ROOT "$ENV{ECW_ROOT}")
+endif()
+
 find_path(ECW_INCLUDE_DIR NCSECWClient.h)
 
 if (ECW_INCLUDE_DIR)


### PR DESCRIPTION
Allows setting ECW_ROOT as environment variable like it's already working with OpenEXR_ROOT, BLOSC_ROOT, BOOST_ROOT

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
